### PR TITLE
collapse indices inside string

### DIFF
--- a/R/hri.R
+++ b/R/hri.R
@@ -182,11 +182,11 @@ hri.default <- function(nStudents=ncol(s.prefs), nColleges=ncol(c.prefs), nSlots
   ## consistency checks
   drop <- which( apply(s.prefs, 2, function(z) sum(!is.na(z))) == 0)
   if( length(drop)>0 ){
-    stop(paste("Need to drop s.prefs column(s):",drop))
+    stop(paste("Need to drop s.prefs column(s):", paste(drop, collapse=", ")))
   }
   drop <- which( apply(c.prefs, 2, function(z) sum(!is.na(z))) == 0)
   if( length(drop)>0 ){
-    stop(paste("Need to drop c.prefs column(s):",drop))
+    stop(paste("Need to drop c.prefs column(s):", paste(drop, collapse=", ")))
   }
   
   ## -------------------------------------------------------


### PR DESCRIPTION
Consider putting all the indices together, instead of repeating the "Need to drop ..." label every time.